### PR TITLE
Validating last 4 cc digits before adding to API request

### DIFF
--- a/Api/RequestHandler.php
+++ b/Api/RequestHandler.php
@@ -173,7 +173,9 @@ class RequestHandler extends \NoFraud\Connect\Api\Request\Handler\AbstractHandle
         $cc['expirationDate'] = $this->buildCcExpDate($payment);
         $cc['cardCode']       = $payment->getCcCid();
 
-        $cc['last4']          = $this->decryptLast4($payment);
+        if ($last4 = $this->decryptLast4($payment)) {
+            $cc['last4'] = $last4;
+        }
 
         $paymentParams = [];
 
@@ -191,7 +193,7 @@ class RequestHandler extends \NoFraud\Connect\Api\Request\Handler\AbstractHandle
             $last4 = $payment->decrypt($last4);
         }
 
-        if ( strlen($last4) == 4 ){
+        if (strlen($last4) == 4 && ctype_digit($last4)) {
             return $last4;
         }
     }


### PR DESCRIPTION
In some cases, we do not have the last four digits of the credit card
stored in our payment table and a placeholder like 'xxxx' is used
instead. The NoFraud API returns an error if the last4 are not all
numbers. This commit adds validation that checks if the last4 pulled
from the database is actually four digits before adding it to the API
request.