### PR TITLE
Changing OrderFraudStatus auto cancel to use correct response variable

### DIFF
--- a/Cron/OrderFraudStatus.php
+++ b/Cron/OrderFraudStatus.php
@@ -70,10 +70,10 @@ class OrderFraudStatus
                     $newStatus = $this->orderProcessor->getCustomOrderStatus($response['http']['response'], $storeId);
                     $this->orderProcessor->updateOrderStatusFromNoFraudResult($newStatus, $order);
 
-	            $order->save();
+                    $order->save();
 
-                    if ($this->configHelper->getAutoCancel($storeId) && isset($resultMap['http']['response']['body']['decision'])) {
-                        $this->orderProcessor->handleAutoCancel($order, $resultMap['http']['response']['body']['decision']);
+                    if ($this->configHelper->getAutoCancel($storeId) && isset($response['http']['response']['body']['decision'])) {
+                        $this->orderProcessor->handleAutoCancel($order, $response['http']['response']['body']['decision']);
                     }
                 }
             } catch (\Exception $exception) {


### PR DESCRIPTION
In the cron job class, it updates orders with new status' when necessary. It is also supposed to cancel orders when their fraud status changes to `fail`. However, the cancellation code is not running because the code is using the `$resultMap` variable instead of `$response`. `$resultMap` does not exist so no fail orders are being canceled. This pull request updates the variable reference to the correct name.