### PR TITLE
hotfix: include version in composer.json to allow for FE display

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
   "name": "nofraud/connect",
   "description": "Sends your transactions to NoFraud for verification of no fraud.",
   "type": "magento2-module",
+  "version": "1.0.1",
   "license": [
     "OSL-3.0"
   ],


### PR DESCRIPTION
While it is the official recommendation of packages and composer that the version key not be used when a VCS is being used, in our case we need to display the version on the FE for debugging. For this reason, we need to re-introduce the version key so that legacy code will continue to function.