### PR TITLE
ci: Update Semantic Release to Bump composer.json Version 

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: "lts/*"
-      - run: npm install -g semantic-release @semantic-release/github @semantic-release/git @semantic-release/changelog
+      - run: npm install -g semantic-release @semantic-release/github @semantic-release/git @semantic-release/changelog @iwavesmedia/semantic-release-composer
       - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE }}

--- a/.github/workflows/version-check.yaml
+++ b/.github/workflows/version-check.yaml
@@ -1,4 +1,4 @@
-name: Check composer.json Version Bumped
+name: Check composer.json Version Not Changed
 on:
   pull_request:
     types:
@@ -7,31 +7,16 @@ on:
 jobs:
   check-version-bumped:
     runs-on: ubuntu-latest
-    steps: 
+    steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Check for releasable commit messages 
-        id: check_commit_messages
-        run: |
-          commits=$(git log --pretty=format:"%s" ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }})
-          if [[ $commits =~ "fix" || $commits =~ "feat" ]]; then
-            echo "Commit messages contain 'fix' or 'feat'. Running file check..."
-            echo "is_release=true" >> $GITHUB_OUTPUT
-          else
-            echo "Skipping further checks as this PR would not generate a release."
-            echo "is_release=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
       - name: Check Version Key Update
-        if: steps.check_commit_messages.outputs.is_release == 'true'
         id: check_version_changes
         run: |
-          changed_lines=$(git diff -r --unified=0 ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} -- composer.json | grep -c "version")
-          if [ "$changed_lines" -eq "0" ]; then
-            echo "Error: version in composer.json must be updated in the pull request"
+          changed_lines=$(git diff -r --unified=0 ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} -- composer.json | grep -c "version") || true
+          if [ "$changed_lines" -ne "0" ]; then
+            echo "Error: version in composer.json should not be updated manually."
             exit 1
           fi
-
-

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -3,11 +3,12 @@ plugins:
 - "@semantic-release/commit-analyzer"
 - "@semantic-release/release-notes-generator"
 - "@semantic-release/github"
+- - "@iwavesmedia/semantic-release-composer"
+  - skipOnMissingComposerJson: true
 - - "@semantic-release/changelog"
   - changelogFile: CHANGELOG.md
 - - "@semantic-release/git"
-  - assets:
-    - CHANGELOG.md
+  - assets: ["CHANGELOG.md", "composer.json"]
 branches:
   - "master"
   - "+([0-9])?(.{+([0-9]),x}).x"


### PR DESCRIPTION
This pull request updates the composer.json file with the appropriate semantic release version and enhances the version check process to fail if the version key is modified in a pull request (PR).

Changes:

ci: update composer.json with semantic release version:
Update the composer.json file to reflect the semantic release version.

ci: Make composer.json version check fail if PR modified version key:
Modify the version check process in the CI pipeline to fail if the version key in composer.json is modified in a PR. This prevents manual meddling with the version which would result in version skew.