### PR TITLE
Make Extension Compatible With Dynamic Property Deprecation in PHP 8.2

### DIFF
--- a/Api/Request/Handler/AbstractHandler.php
+++ b/Api/Request/Handler/AbstractHandler.php
@@ -10,6 +10,11 @@ class AbstractHandler
     protected $logger;
 
     /**
+     * @var \Magento\Framework\HTTP\Client\Curl $curl
+     */
+    protected $_curl;
+
+    /**
      * AbstractHandler constructor.
      * @param \NoFraud\Connect\Logger\Logger $logger
      * @param \Magento\Framework\HTTP\Client\Curl $curl

--- a/Cron/NotifyNofauad.php
+++ b/Cron/NotifyNofauad.php
@@ -23,6 +23,10 @@ class NotifyNofauad
      */
     protected $transportBuilder;
     /**
+     * @var orderCollectionFactory
+     */
+    protected $orderCollectionFactory;
+    /**
      * @var inlineTranslation
      */
     protected $inlineTranslation;

--- a/Cron/OrderFraudStatus.php
+++ b/Cron/OrderFraudStatus.php
@@ -20,6 +20,10 @@ class OrderFraudStatus
      */
     private $requestHandler;
     /**
+     * @var DataHelper
+     */
+    private $dataHelper;
+    /**
      * @var ConfigHelper
      */
     private $configHelper;

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -37,6 +37,11 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     protected $logDirectory;
 
     /**
+     * @var DirectoryList
+     */
+    protected $directoryList;
+
+    /**
      * Constructor
      *
      * @param \Magento\Framework\App\Helper\Context $context


### PR DESCRIPTION
PHP 8.2 deprecated the use of Dynamic Properties. This is causing a fatal error and crash in Magento. This PR removes the use of dynamic properties in favor of directly declaring the affected properties in the class.