### PR TITLE
fix: Orders that fail screening should have appropriate status set

### DIFF
--- a/Observer/SalesOrderPaymentPlaceEnd.php
+++ b/Observer/SalesOrderPaymentPlaceEnd.php
@@ -184,19 +184,7 @@ class SalesOrderPaymentPlaceEnd implements \Magento\Framework\Event\ObserverInte
                 $nofraudDecision = $resultMap['http']['response']['body']['decision'] ?? "";
                 if (isset($nofraudDecision) && !empty($nofraudDecision)) {
                     $newStatus = $this->orderProcessor->getCustomOrderStatus($resultMap['http']['response'], $storeId);
-                    if (isset($nofraudDecision) && ($nofraudDecision == 'error')) {
-                        if (!empty($newStatus)) {
-                            $this->orderProcessor->updateOrderStatusFromNoFraudResult($newStatus, $order, $resultMap);
-                        }
-                    }
-                    if (isset($nofraudDecision) && ($nofraudDecision == 'pass')) {
-                        if (!empty($newStatus)) {
-                            $this->orderProcessor->updateOrderStatusFromNoFraudResult($newStatus, $order, $resultMap);
-                        }
-                    }
-                    if (isset($nofraudDecision) && ($nofraudDecision == 'review')) {
-                        $this->orderProcessor->updateOrderStatusFromNoFraudResult($newStatus, $order, $resultMap);
-                    }
+                    $this->orderProcessor->updateOrderStatusFromNoFraudResult($newStatus, $order, $resultMap);
                 } else {
                     $nofraudErrorDecision = $resultMap['http']['response']['body']['Errors'] ?? "";
                     if (isset($nofraudErrorDecision) && !empty($nofraudErrorDecision)) {
@@ -212,10 +200,8 @@ class SalesOrderPaymentPlaceEnd implements \Magento\Framework\Event\ObserverInte
             $order->save();
 
             // If order fails screening and auto-cancel is enabled in admin config, cancel the order
-            if ($this->configHelper->getAutoCancel($storeId)) {
-                if (isset($nofraudDecision) && $nofraudDecision == 'fail') {
-                    $this->orderProcessor->handleAutocancel($order, $nofraudDecision);
-                }
+            if ($this->configHelper->getAutoCancel($storeId) && isset($nofraudDecision) && $nofraudDecision == 'fail') {
+                $this->orderProcessor->handleAutocancel($order, $nofraudDecision);
             }
         } catch (\Exception $exception) {
             $this->logger->logFailure($order, $exception);


### PR DESCRIPTION
This PR fixes the following cases reported by the QE team:

Review to Fail (when Auto-Cancel is disabled)- Order status does not match what is set in the backend
Fail (when Auto-Cancel is enabled/disabled) - Order status does not match what is set in the backend