### PR TITLE
(OCI-477) Fix Order Processing, Holding and State Collection in Cron Jobs

### DIFF
--- a/Cron/OrderFraudStatus.php
+++ b/Cron/OrderFraudStatus.php
@@ -101,6 +101,7 @@ class OrderFraudStatus
             ->addFieldToSelect('entity_id')
             ->addFieldToSelect('nofraud_status')
             ->addFieldToSelect('nofraud_transaction_id')
+            ->addFieldToSelect('state')
             ->setOrder('status', 'desc');
 
         $orderStatusReview = $this->configHelper->getOrderStatusReview($storeId);

--- a/Cron/OrderFraudStatus.php
+++ b/Cron/OrderFraudStatus.php
@@ -146,6 +146,13 @@ class OrderFraudStatus
 
                 // Extract new decision from the response.
                 $decision = $response['http']['response']['body']['decision'] ?? "";
+
+                // If the decision has not changed, skip the order.
+                if ($decision == 'review') {
+                    $this->dataHelper->addDataToLog("Decision has not changed for Order#" . $order['increment_id']);
+                    continue;
+                }
+
                 // Translate the decision into a status based on the configuration.
                 $newStatus = $this->orderProcessor->getCustomOrderStatus($response['http']['response'], $storeId);
 


### PR DESCRIPTION
### Pull Request: Fix Order Processing and State Collection in Cron Jobs

#### Overview
This pull request addresses two critical issues in the cron job's handling of order status updates and state collection, improving the efficiency and accuracy of order processing.

#### Fixes Reported Issue
The fix addresses a specific issue identified in the order processing workflow when On Hold status is used for both Pass and Fail NoFraud statuses:

1. **Order Lifecycle**:
   - Order placed
   - Order flagged for review
   - Order put on hold via plugin
   - Order fails review and remains on hold in Magento as configured.

2. **Issue with Unholding**:
   - In this situation, it becomes impossible to unhold the order.
   - Attempting to unhold results in the order status becoming blank, and the hold button reappears.
   - Clicking the hold button again only updates the status back to on hold.

#### Changes
1. **Avoid Repeated Order Holds in NoFraud Decision Processing**:
   - Modified the `updateOrdersFromNoFraudApiResult` method in `Order/Processor.php`.
   - Added a check to skip holding the order if the NoFraud decision has not changed (still in 'review'). This prevents redundant operations on the same order.

2. **Include Order State in Cron Collection**:
   - Updated the `readOrders` function in `Order/Processor.php`.
   - Added `state` to the list of fields selected during order collection. This inclusion ensures that the check for an order's holdability is now functional.

#### Technical Details
- **File**: `Order/Processor.php`
   - **Function**: `readOrders`
     - Added `addFieldToSelect('state')` to include the state in the order collection.
   - **Function**: `updateOrdersFromNoFraudApiResult`
     - Added a conditional statement to skip orders where the NoFraud decision is 'review'.

- **File**: `Order/Processor.php`
   - **Function**: `updateOrderStatusFromNoFraudResult`
     - Enhanced the hold logic by checking `if ($order->canHold())` before attempting to hold an order.

#### Impact
- **Performance**: Reduces unnecessary processing in the cron job, leading to improved performance.
- **Accuracy**: Ensures accurate and appropriate actions are taken based on the current state of orders.

#### Request for Review
Kindly review the changes for accuracy and efficiency. Testing on a staging environment is recommended before merging into the production branch.
