### PR TITLE
fix: Prevent Authnet plugin from transitioning status in conflict with

### DIFF
--- a/Plugin/SetInitialOrderStatusPlugin.php
+++ b/Plugin/SetInitialOrderStatusPlugin.php
@@ -20,13 +20,6 @@ class SetInitialOrderStatusPlugin
         callable $proceed,
         Observer $observer
     ) {
-        // Add custom NoFraud logic to stop execution
-        $order = $observer->getEvent()->getOrder();
-        if ($order) {
-            $order->addCommentToStatusHistory('NoFraud: Original logic skipped by plugin.');
-        }
-
         // Return without calling $proceed to stop original logic
-        return;
     }
 }

--- a/Plugin/SetInitialOrderStatusPlugin.php
+++ b/Plugin/SetInitialOrderStatusPlugin.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace NoFraud\Connect\Plugin;
+
+use ParadoxLabs\TokenBase\Observer\SetInitialOrderStatusObserver;
+use Magento\Framework\Event\Observer;
+
+class SetInitialOrderStatusPlugin
+{
+    /**
+     * Around plugin for execute method.
+     *
+     * @param SetInitialOrderStatusObserver $subject
+     * @param callable $proceed
+     * @param Observer $observer
+     * @return void
+     */
+    public function aroundExecute(
+        SetInitialOrderStatusObserver $subject,
+        callable $proceed,
+        Observer $observer
+    ) {
+        // Add custom NoFraud logic to stop execution
+        $order = $observer->getEvent()->getOrder();
+        if ($order) {
+            $order->addCommentToStatusHistory('NoFraud: Original logic skipped by plugin.');
+        }
+
+        // Return without calling $proceed to stop original logic
+        return;
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -33,4 +33,7 @@
             </argument>
         </arguments>
     </virtualType>
+    <type name="ParadoxLabs\TokenBase\Observer\SetInitialOrderStatusObserver">
+        <plugin name="nofraud_set_initial_order_status_plugin" type="NoFraud\Connect\Plugin\SetInitialOrderStatusPlugin" />
+    </type>
 </config>


### PR DESCRIPTION
# Pull Request: Fix Conflict with Paradox Labs Authnet Plugin Status Transition

## Description

This pull request introduces a fix to prevent conflicts with the Paradox Labs Authnet plugin during order status transitions. The issue arises when the default logic in the `SetInitialOrderStatusObserver` executes, potentially conflicting with NoFraud's requirements.

## Changes Made

1. **Added a Plugin:**
   - Introduced the `SetInitialOrderStatusPlugin` in `Plugin/SetInitialOrderStatusPlugin.php`.
   - The plugin overrides the `execute` method of `SetInitialOrderStatusObserver` to prevent the original logic from running.

2. **Updated Dependency Injection Configuration:**
   - Added a plugin declaration in `etc/di.xml` to bind `NoFraud\Connect\Plugin\SetInitialOrderStatusPlugin` to `ParadoxLabs\TokenBase\Observer\SetInitialOrderStatusObserver`.

## Testing

### Steps to Test:

1. Place an order using the Paradox Labs Authnet plugin.
2. Ensure that the original logic in `SetInitialOrderStatusObserver` does not execute.

### Expected Outcome:

- Order processing continues without the original logic interfering.
